### PR TITLE
Fix header layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,7 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  margin: 0;
+  padding: 0;
+  text-align: left;
 }
 
 .logo {

--- a/src/components/landing/Header.tsx
+++ b/src/components/landing/Header.tsx
@@ -47,7 +47,7 @@ export const Header = () => {
       <div className="container mx-auto px-4">
         <div className="grid grid-cols-3 items-center h-20">
           {/* Logo */}
-          <div className="text-xl font-bold text-inforia-light">
+          <div className="text-xl font-bold text-inforia-light text-left">
             iNFORiA
           </div>
           


### PR DESCRIPTION
## Summary
- align header brand on the left and keep nav centered
- remove restrictive `#root` styling so header no longer overflows

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68512604038c83339aa4b8a6075c5ab1